### PR TITLE
Fix Pause/ Play Logic & Sync Slider to Pause/ Play Btn

### DIFF
--- a/src/app/containers/TravelContainer.tsx
+++ b/src/app/containers/TravelContainer.tsx
@@ -8,6 +8,7 @@ import {
   moveForward,
   moveBackward,
   resetSlider,
+  changeSlider,
 } from '../slices/mainSlice';
 import { useDispatch, useSelector } from 'react-redux';
 import { MainState, RootState, TravelContainerProps } from '../FrontendTypes';
@@ -40,6 +41,7 @@ function play( // function that will start/pause slider movement
   if (playing) {
     // if already playing, clicking the button will pause the slider
     dispatch(pause());
+
   } else {
     let currentIndex = sliderIndex; // the 'currentIndex' will be wherever the 'sliderIndex' is
     if (currentIndex === snapshotsLength - 1) {
@@ -53,6 +55,7 @@ function play( // function that will start/pause slider movement
         // as long as we're not the last snapshot, increment slider up through our dispatch and increment index
         dispatch(playForward(true));
         currentIndex += 1;
+        dispatch(changeSlider(currentIndex));
       } else {
         dispatch(pause()); // pause the slider when we reach the end
       }

--- a/src/app/slices/mainSlice.ts
+++ b/src/app/slices/mainSlice.ts
@@ -90,7 +90,6 @@ export const mainSlice = createSlice({
             ...payload[tab],
             intervalId: tabs[tab].intervalId,
             playing: tabs[tab].playing,
-            //sliderIndex: newSnaps.length - 1,
             sliderIndex: tabs[tab].sliderIndex,
             seriesSavedStatus: false,
           };

--- a/src/app/slices/mainSlice.ts
+++ b/src/app/slices/mainSlice.ts
@@ -88,7 +88,10 @@ export const mainSlice = createSlice({
           const { snapshots: newSnaps } = payload[tab];
           tabs[tab] = {
             ...payload[tab],
-            sliderIndex: newSnaps.length - 1,
+            intervalId: tabs[tab].intervalId,
+            playing: tabs[tab].playing,
+            //sliderIndex: newSnaps.length - 1,
+            sliderIndex: tabs[tab].sliderIndex,
             seriesSavedStatus: false,
           };
         }


### PR DESCRIPTION
1. Addressed Timing Bug in Start/Pause Logic:
- Resolved an issue where properties such as intervalId, playing, and sliderIndex were resetting to undefined due to state changes during play.
- Implemented logic to persist these properties, ensuring they are retained across state updates. This fix enables proper handling of the pause functionality and ensures intervals are cleared at the correct times.

2. Synced Slider with Pause/Play Button:
- call changeSlider within the play logic to ensure the slider's state matches the currentIndex during playback.